### PR TITLE
Changed getter return syntax to allow solution to build.

### DIFF
--- a/src/FormulaCS.Evaluator/FunctionArgs.cs
+++ b/src/FormulaCS.Evaluator/FunctionArgs.cs
@@ -12,7 +12,7 @@ namespace FormulaCS.Evaluator
 
         public object Result
         {
-            get => result;
+            get { return result; } 
             set
             {
                 result = value;


### PR DESCRIPTION
Hi,

I tried to build using Visual Studio 2015, but was getting errors preventing it from building.
I changed the Getter and it allowed it to build.

For reference this is the version of VS I was using.

Microsoft Visual Studio Community 2015
Version 14.0.25425.01 Update 3
Microsoft .NET Framework
Version 4.7.02046

Should I change to a different version?  
Please let me know what you think.

Thanks,

Alex